### PR TITLE
Small bunch of additions and clarifications

### DIFF
--- a/imageboards.json
+++ b/imageboards.json
@@ -330,7 +330,8 @@
       "https://p.0chan.pl/",
       "https://www.0chan.club/",
       "https://ygg.0chan.pl/",
-      "http://[202:7668:15bf:63df:d7ee:aab7:ece:fbbb]/"
+      "http://[202:7668:15bf:63df:d7ee:aab7:ece:fbbb]/",
+      "http://0chan.ygg/"
     ],
     "language": [
       "ru"
@@ -350,6 +351,18 @@
     "software": [
       "tinyboard",
       "vichan"
+    ]
+  },
+  {
+    "name": "0kun",
+    "url": "https://www.0kun.net/",
+    "language": [
+      "ru",
+      "en"
+    ],
+    "software": [
+      "tinyib",
+      "0kun-tinyib"
     ]
   },
   {
@@ -1542,7 +1555,16 @@
     ],
     "software": [
       "kusaba",
-      "kusabax"
+      "kusabax",
+      "instant-0chan"
+    ],
+    "mirrors": [
+      "https://0chan.cc/",
+      "https://0chan-cc.ngmt.host/"
+    ],
+    "boardlist": [
+      "https://0chan.cc/boards10.json",
+      "https://0chan.cc/boards20.json"
     ]
   },
   {

--- a/software.md
+++ b/software.md
@@ -51,7 +51,7 @@ This is a list of the software codes used in imageboard.json along with links to
     - phutaba - https://github.com/ernstchan/phutaba
     - taimaba - used by https://420chan.org/
 - tinyib - https://gitlab.com/tslocum/tinyib
-    - 0kub-tinyib - https://gitgud.io/devarped/0kun-tinyib
+    - 0kun-tinyib - https://gitgud.io/devarped/0kun-tinyib
 - doushio - https://github.com/lalcmellkmal/doushio
     - meguca - https://github.com/bakape/meguca
         - cutechan - https://github.com/cutechan/cutechan

--- a/software.md
+++ b/software.md
@@ -51,6 +51,7 @@ This is a list of the software codes used in imageboard.json along with links to
     - phutaba - https://github.com/ernstchan/phutaba
     - taimaba - used by https://420chan.org/
 - tinyib - https://gitlab.com/tslocum/tinyib
+    - 0kub-tinyib - https://gitgud.io/devarped/0kun-tinyib
 - doushio - https://github.com/lalcmellkmal/doushio
     - meguca - https://github.com/bakape/meguca
         - cutechan - https://github.com/cutechan/cutechan


### PR DESCRIPTION
* Clarified origin of 0chan.cc engine, added boardlist json and a hidden
mirror.
* Added another 0chan.pl Yggdrasil mirror, which uses Wyrd domain name
system.
* Added 0kun.net, a joke spoof of 2003 0chan.net, which also serves as a
bunker board for 0chan.pl in case of maintenance.