### PR TITLE
Remove tumba.ch and its mirrors

### DIFF
--- a/imageboards.json
+++ b/imageboards.json
@@ -5171,29 +5171,6 @@
     ]
   },
   {
-    "name": "Tumbach",
-    "url": "https://tumba.ch/",
-    "mirrors": [
-      "https://tumba.ch/",
-      "http://tumbachegvyaadyq.onion/",
-      "http://tumbach3fog3l35w7usf5fgx37eaif2zb266dc3s5jw7gmhg6hsm7aad.onion/"
-    ],
-    "language": [
-      "ru"
-    ],
-    "software": [
-      "ololord.js",
-      "tumbach"
-    ]
-  },
-  {
-    "name": "Tumbach test",
-    "url": "https://tuderi.tumba.ch/test/",
-    "language": [
-      "ru"
-    ]
-  },
-  {
     "name": "tuzach.in",
     "url": "https://tuzach.in/",
     "language": [


### PR DESCRIPTION
It is unfortunate to report that Tumbach is on the verge of closing.
Most likely, imageboard will close before the end of this summer, and all of its services (like radio) will become private.

The fork branch of the ololord.js engine (https://github.com/rngnrs/tumbach) has been discontinued and will no longer be supported.
The public test is going private, so it makes no sense to be on this list.

There are some great guys in the Russian (and not only Russian) board scene who are worthy of attention, and I think they can do a better job than me.
My personal apologies to all those who were with us, fighting and running away in despair.