### PR TITLE
Remove 0chan.pl and 1chan.pl

### DIFF
--- a/imageboards.json
+++ b/imageboards.json
@@ -402,37 +402,6 @@
     "boardlist": "https://4.0-chan.ru/json/board-list"
   },
   {
-    "name": "0chan.pl",
-    "url": "https://www.0chan.pl/",
-    "mirrors": [
-      "https://www.0chan.pl/",
-      "https://p.0chan.pl/",
-      "https://0.1chan.pl/",
-      "https://www.0chan.club/",
-      "http://nullplctggmjazqcoboc2pw5anogckczzj6xo45ukrnsaxarpswu7sid.onion/",
-      "http://gd7qe2pu2jwqabz4zcf3wwablrzym7p6qswczoapkm5oa5ouuaua.b32.i2p/",
-      "http://0pl.i2p/",
-      "http://[225:55:9ebf:1709:7b1f:a315:1119:6eff]/",
-      "http://0chan.ygg/",
-      "https://ygg.0chan.pl/"
-    ],
-    "redirects": [
-      "http://nullchpl673e6jo3.onion/",
-      "http://[202:7668:15bf:63df:d7ee:aab7:ece:fbbb]/"
-    ],
-    "fallbacks": [
-      "https://www1.0kun.net/"
-    ],
-    "language": [
-      "ru"
-    ],
-    "software": [
-      "0chan",
-      "ochko"
-    ],
-    "boardlist": "https://www.0chan.pl/api/board/list"
-  },
-  {
     "name": "0kun",
     "url": "https://www.0kun.net/",
     "language": [
@@ -536,24 +505,6 @@
     ],
     "software": [
       "1chan"
-    ]
-  },
-  {
-    "name": "1chan.pl",
-    "url": "https://1chan.pl/news/",
-    "mirrors": [
-      "https://1chan.pl/",
-      "http://kolchpl6sf4t7yjf57an3gxyprqqtjm2gtvatzkcsx27uu3psssnmyad.onion/"
-    ],
-    "redirects": [
-      "http://kolchplzpprjfa7e.onion/"
-    ],
-    "language": [
-      "ru"
-    ],
-    "software": [
-      "1chan",
-      "pierwszykanal"
     ]
   },
   {

--- a/software.md
+++ b/software.md
@@ -72,9 +72,7 @@ This is a list of the software codes used in imageboard.json along with links to
     - bakareha - https://github.com/f2d/bakareha
 - exaba - http://web.archive.org/web/20150429042034/http://exachan.com/exaba/ (last archived release: http://web.archive.org/web/20130614124246/http://exachan.com/exaba/downloads/exaba_0_9_9.zip)
 - 0chan - https://github.com/klkvsk/0chan
-    - ochko - https://gitgud.io/devarped/ochko
 - 1chan - https://github.com/jlbyrey/1chan
-    - pierwszykanal - https://gitgud.io/devarped/pierwszykanal
 - atbbs - https://sourceforge.net/projects/atbbs/
     - tinybbs - https://github.com/r04r/minichan
 - bbsnote - http://web.archive.org/web/20050116004959/http://wondercatstudio.com:80/html/download.html


### PR DESCRIPTION
0chan.pl is closed due to lack of interest.
1chan.pl has posting locked for about a year and might be shut down soon as well.